### PR TITLE
Unify shortcuts

### DIFF
--- a/.github/scripts/update_appcast.sh
+++ b/.github/scripts/update_appcast.sh
@@ -11,7 +11,7 @@ echo "
     <item>
       <title>Version $VERSION</title>
       <pubDate>$DATE</pubDate>
-      <sparkle:minimumSystemVersion>10.12</sparkle:minimumSystemVersion>
+      <sparkle:minimumSystemVersion>10.14.4</sparkle:minimumSystemVersion>
       <description><![CDATA[
 $CHANGELOG
       ]]>

--- a/.github/templates/release_notes.md
+++ b/.github/templates/release_notes.md
@@ -1,3 +1,13 @@
-<h1>New Preference Window and Shortcut Custimization</h1>
+<h1>New Shortcuts</h1>
 
-This update introduces a new Preferences window. Here, you can customize the global shortcut for the host app as well as adjust the behaviour of the update mechanism.
+With this update Pass for macOS unifies the shortcuts and changes the auto-fill behaviour.
+
+<b><i>Note: This update breaks compatibility with macOS version older than 10.14.4 (Mojave).</i></b>
+
+<h2>Using the shortcut outside of Safari</h2>
+By using the default shortcut `shift-ctrl-p` (or the user-defined shortcut from the preferences), a popover will be shown containing a search field. Here, you can search for passwords. Selecting a search result by double-click or with enter will copy the password to the clipboard, exactly as `pass -c <password>` does.
+
+<h2>Using the shortcut in Safari</h2>
+When you use the shortcut within Safari, Pass for macOS will search a password containing the current domain.
+If only one matching password was found, Pass for macOS will auto-fill the credentials and notify you with a little notification in the top right corner.
+If more than one matching password was found, the popover in the toolbar will show and you can manually select the correct password (which will be used for auto-fill) or refine the search.

--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ Second, a [Safari App Extensions](https://developer.apple.com/documentation/safa
 * Autofill passwords from the list of found passwords in Safari.
 
 ### Limitations
-* The popover view in Safari can not be shown using the provided shortcut. Therefore, the first password for the current domain will be auto-filled if multiple exist.
 * OTP is not supported.
-* Pass for macOS was tested macOS Mojave (10.14), Catalina (10.15) and Big Sur (11.0)  with Safari 12 and 13 and 14, although it should work starting with macOS Sierra (10.12) and Safari 10.
+* Pass for macOS requires macOS Mojave (10.14.4), Catalina (10.15) and Big Sur (11.0) with Safari 12 and 13 and 14.
 
 ## Table of Contents
 * [Requirements](#requirements)
@@ -40,7 +39,7 @@ Second, a [Safari App Extensions](https://developer.apple.com/documentation/safa
 * [Contributing](#contributing)
 
 ## Requirements
-* macOS Sierra or later
+* macOS Mojave or later
 * `pass` (obviously)
 * The first line of the password file has to be the password, the second line has to start with `login:`, `user:` or `username:`, followed by your username. All other lines after that are not considered. See the following example:
 
@@ -92,7 +91,7 @@ You can use your self-built Pass for macOS.
 
 ### Updating Pass for macOS
 Starting with version 0.7, Pass for macOS uses the [Sparkle Project](https://sparkle-project.org) for automatic updates.
-Therefore, a new right-click context menu was added, which allows you to either check for updates manually or enable daily checks.
+Therefore, you can use the preferences (accessed via right-clicking the status bar item), which allows you to either check for updates manually or enable automatic checks.
 
 For updating from versions < 0.7 to >= 0.7, you need to uninstall Pass for macOS and disable the extension in Safari.
 After the installation, everything should be fine.
@@ -111,7 +110,7 @@ However, to give it some meaning, a status bar item is added.
 <img src="Screenshots/host.png" width="500">
 
 By clicking on the status bar item or using the defailt shortcut `shift-ctrl-p`, a popup will be shown containing a search field.
-Here, you can search for password.
+Here, you can search for passwords.
 Selecting a search result by double-click or with enter will copy the password to the clipboard, exactly as `pass -c <password>` does.
 
 #### Settings
@@ -131,7 +130,7 @@ Additionally, you can search manually for updates.
 
 ### The extension
 The extension has two modes.
-You can click the toolbar item or use a shortcut.
+You can click the toolbar item or use the same shortcut as the host app uses.
 
 #### Toolbar
 <img src="Screenshots/extension.png" width="500">
@@ -143,16 +142,10 @@ If the password was not correctly found, you can refine the search using the sea
 #### Shortcut
 <img src="Screenshots/shortcut.png" width="500">
 
-Pass for macOS' Safari extension also offers a shortcut:
-
-```
-shift-alt-p
-```
-
-Unfortunately, Apple does not offer an option to invoke the Safari toolbar popover when a shortcut is pressed.
-Therefore, Pass for macOS will search a password containing the current domain as for the toolbar popover and autofill the first found password.
-If you have multiple logins for a domain, only the first one will be used using the shortcut.
-You will see a little notification on the top right if a password is auto-filled using the shortcut.
+But you can also use the shortcut from above.
+Pass for macOS will search a password containing the current domain as for the toolbar popover.
+If only one matching password was found, Pass for macOS will auto-fill the credentials and notify you with a little notification in the top right corner.
+If more than one matching password was found, the popover in the toolbar will show and you can manually select the correct password or refine the search.
 
 ## Contributing
 Any help is welcome, regardless if issue, pull request or comment.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Second, a [Safari App Extensions](https://developer.apple.com/documentation/safa
 
 ### Limitations
 * OTP is not supported.
-* Pass for macOS requires macOS Mojave (10.14.4), Catalina (10.15) and Big Sur (11.0) with Safari 12 and 13 and 14.
+* Pass for macOS requires macOS Mojave (10.14.4), Catalina (10.15) and Big Sur (11.0) with Safari 12 and 13 and 14. Pass for macOS versions 0.9 or earlier also work on macOS 10.12 and 10.13. See the installation instructions below for more information.
 
 ## Table of Contents
 * [Requirements](#requirements)
@@ -39,7 +39,7 @@ Second, a [Safari App Extensions](https://developer.apple.com/documentation/safa
 * [Contributing](#contributing)
 
 ## Requirements
-* macOS Mojave or later
+* macOS Mojave or later (for older macOS versions, see the installation instructions below.)
 * `pass` (obviously)
 * The first line of the password file has to be the password, the second line has to start with `login:`, `user:` or `username:`, followed by your username. All other lines after that are not considered. See the following example:
 
@@ -62,6 +62,8 @@ You have three options to use Pass for macOS: use the Github releases, homebrew 
 Download the latest version of the app from the releases page and drop it in your applications folder.
 Thats it.
 
+Please note, that if you are using macOS 10.14.3 or older, the last working version of Pass for macOS is 0.9, so you should download this release.
+
 ### Option 2: Use Homebrew
 You can install Pass for macOS using homebrew.
 Just run the following command:
@@ -69,6 +71,8 @@ Just run the following command:
 ```
 brew cask install adur1990/tap/passformacos
 ```
+
+Please note, that this installation method does not work on macOS versions older than macOS 10.14.3.
 
 ### Option 3: Build it yourself
 You can  build Pass for macOS yourself.
@@ -101,6 +105,9 @@ To the best of my knowledge, it is not possible to enable the hardened runtime f
 Therefore, you have to **right-click** or **ctrl-click** on `Pass for macOS.app` and select `open`. macOS will ask you, if you are really sure to open this "potentially malicous" app. If you confirm, you are free to use Pass for macOS.
 
 After that, start Safari, go to Preferences and enable the extension.
+
+Please note, that the following usage instructions all refer to Pass for macOS version 0.10 and later.
+If you are using Pass for macOS version 0.9 or older, find the usage instructions [here](https://github.com/adur1990/Pass-for-macOS/blob/01eb387bcc274785ef0166164371093067405ccb/README.md#usage)
 
 ### The host app
 Since Pass for macOS uses the host app to handle the security related password stuff, it has to run all the time.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ However, to give it some meaning, a status bar item is added.
 #### Status Bar
 <img src="Screenshots/host.png" width="500">
 
-By clicking on the status bar item or using the defailt shortcut `shift-ctrl-p`, a popup will be shown containing a search field.
+By clicking on the status bar item or using the default shortcut `shift-ctrl-p`, a popup will be shown containing a search field.
 Here, you can search for passwords.
 Selecting a search result by double-click or with enter will copy the password to the clipboard, exactly as `pass -c <password>` does.
 

--- a/extension/Base.lproj/SafariExtensionViewController.xib
+++ b/extension/Base.lproj/SafariExtensionViewController.xib
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -44,14 +45,13 @@
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowSizeStyle="automatic" viewBased="YES" id="4gY-te-H9m">
                                 <rect key="frame" x="0.0" y="0.0" width="328" height="1"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn editable="NO" width="325" minWidth="40" maxWidth="1000" id="WUP-QW-L4n">
+                                    <tableColumn editable="NO" width="316" minWidth="40" maxWidth="1000" id="WUP-QW-L4n">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -81,7 +81,7 @@
                     </scroller>
                 </scrollView>
                 <button focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Gjk-6y-lsc">
-                    <rect key="frame" x="-6" y="-7" width="342" height="32"/>
+                    <rect key="frame" x="-7" y="-7" width="344" height="32"/>
                     <buttonCell key="cell" type="push" title="Start Pass for macOS" bezelStyle="rounded" alignment="center" borderStyle="border" focusRingType="none" imageScaling="proportionallyDown" inset="2" id="HUb-eB-6Nd">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>

--- a/extension/SafariExtensionViewController.swift
+++ b/extension/SafariExtensionViewController.swift
@@ -103,7 +103,7 @@ class SafariExtensionViewController: SFSafariExtensionViewController {
         }
         
         // Do not set the focus, if app is not running, no passwords where found or the shortcut was used.
-        var fail: Bool = false;
+        var fail: Bool = false
         if resultsPasswords!.count == 1 {
             if resultsPasswords![0] == "Pass for macOS is not running." {
                 startPassformacosButton.isHidden = false

--- a/extension/passformacosFillForm.js
+++ b/extension/passformacosFillForm.js
@@ -29,13 +29,6 @@ safari.self.addEventListener("message", function (event) {
     }
 });
 
-document.onkeydown = function(keyEvent) {
-    if (keyEvent.altKey && keyEvent.shiftKey && keyEvent.which == 80) {
-        keyEvent.preventDefault();
-        safari.extension.dispatchMessage("fillShortcutPressed");
-    }
-};
-
 window.onload = function() {
     if (window.top != window.self) {
         return

--- a/passformacos.xcodeproj/project.pbxproj
+++ b/passformacos.xcodeproj/project.pbxproj
@@ -511,7 +511,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.14.4;
 				MARKETING_VERSION = 0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.artursterz.passformacos;
 				PRODUCT_NAME = "Pass for macOS";
@@ -540,7 +540,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.14.4;
 				MARKETING_VERSION = 0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.artursterz.passformacos;
 				PRODUCT_NAME = "Pass for macOS";
@@ -563,7 +563,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.14.4;
 				MARKETING_VERSION = 0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.artursterz.passformacos.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -587,7 +587,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.14.4;
 				MARKETING_VERSION = 0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.artursterz.passformacos.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/passformacos.xcodeproj/project.pbxproj
+++ b/passformacos.xcodeproj/project.pbxproj
@@ -500,7 +500,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 0.9;
+				CURRENT_PROJECT_VERSION = 0.10;
 				DEVELOPMENT_TEAM = BR355MFMD5;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -512,7 +512,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 0.9;
+				MARKETING_VERSION = 0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.artursterz.passformacos;
 				PRODUCT_NAME = "Pass for macOS";
 				PROVISIONING_PROFILE_SPECIFIER = "Pass for macOS";
@@ -529,7 +529,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 0.9;
+				CURRENT_PROJECT_VERSION = 0.10;
 				DEVELOPMENT_TEAM = BR355MFMD5;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -541,7 +541,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 0.9;
+				MARKETING_VERSION = 0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.artursterz.passformacos;
 				PRODUCT_NAME = "Pass for macOS";
 				PROVISIONING_PROFILE_SPECIFIER = "Pass for macOS";
@@ -555,7 +555,7 @@
 				CODE_SIGN_ENTITLEMENTS = extension/extension.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 0.9;
+				CURRENT_PROJECT_VERSION = 0.10;
 				DEVELOPMENT_TEAM = BR355MFMD5;
 				INFOPLIST_FILE = extension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -564,7 +564,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 0.9;
+				MARKETING_VERSION = 0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.artursterz.passformacos.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Pass for macOS Extension";
@@ -579,7 +579,7 @@
 				CODE_SIGN_ENTITLEMENTS = extension/extension.entitlements;
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 0.9;
+				CURRENT_PROJECT_VERSION = 0.10;
 				DEVELOPMENT_TEAM = BR355MFMD5;
 				INFOPLIST_FILE = extension/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -588,7 +588,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				MARKETING_VERSION = 0.9;
+				MARKETING_VERSION = 0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = de.artursterz.passformacos.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Pass for macOS Extension";

--- a/passformacos/AppDelegate.swift
+++ b/passformacos/AppDelegate.swift
@@ -59,7 +59,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         contextMenu.addItem(withTitle: "Quit", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
 
         popover.contentViewController = ViewController.newController()
-        popover.behavior = NSPopover.Behavior.transient;
+        popover.behavior = NSPopover.Behavior.transient
 
         KeyboardShortcuts.onKeyUp(for: .togglePopupShortcut) { [self] in
             self.handleShortcut(nil)
@@ -72,8 +72,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func handleShortcut(_ sender: Any?) {
         if safariIsActive() {
-            print("Safari is active and has at least one window.")
-            print("We should send found passwords to the Safari extension.")
+            SFSafariApplication.dispatchMessage(withName: "fillShortcutPressed", toExtensionWithIdentifier: "de.artursterz.passformacos.extension", userInfo: nil, completionHandler: nil)
         } else {
             self.togglePopover(nil)
         }

--- a/passformacos/AppDelegate.swift
+++ b/passformacos/AppDelegate.swift
@@ -73,7 +73,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc func togglePopover(_ sender: Any?) {
         let event = NSApp.currentEvent!
         if event.type == NSEvent.EventType.rightMouseUp {
-            statusBarItem.popUpMenu(contextMenu)
+            statusBarItem.menu = contextMenu
+            statusBarItem.button?.performClick(nil)
+            statusBarItem.menu = nil
         } else {
             if popover.isShown {
               closePopover(sender: sender)

--- a/passformacos/AppDelegate.swift
+++ b/passformacos/AppDelegate.swift
@@ -43,7 +43,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         if let button = statusBarItem.button {
             button.image = NSImage(named: "statusIcon")
-            button.action = #selector(handleMainEvent(_:))
+            button.action = #selector(togglePopover(_:))
             button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         }
 
@@ -62,7 +62,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         popover.behavior = NSPopover.Behavior.transient;
 
         KeyboardShortcuts.onKeyUp(for: .togglePopupShortcut) { [self] in
-            self.handleMainEvent(nil)
+            self.handleShortcut(nil)
         }
     }
 
@@ -70,13 +70,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Insert code here to tear down your application
     }
 
-    @objc func handleMainEvent(_ sender: Any?) {
+    @objc func handleShortcut(_ sender: Any?) {
         if safariIsActive() {
             print("Safari is active and has at least one window.")
             print("We should send found passwords to the Safari extension.")
         } else {
-            print("Safari is either not active or has no windows.")
-            print("We should toggle the popup.")
+            self.togglePopover(nil)
         }
     }
 
@@ -110,7 +109,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return false
     }
 
-    func togglePopover(_ sender: Any?) {
+    @objc func togglePopover(_ sender: Any?) {
         let event = NSApp.currentEvent!
         if event.type == NSEvent.EventType.rightMouseUp {
             statusBarItem.menu = contextMenu

--- a/passformacos/ViewController.swift
+++ b/passformacos/ViewController.swift
@@ -89,7 +89,7 @@ class ViewController: NSViewController {
         }
 
         let delegate = NSApplication.shared.delegate as! AppDelegate
-        delegate.handleMainEvent(nil)
+        delegate.togglePopover(nil)
     }
     
 }

--- a/passformacos/ViewController.swift
+++ b/passformacos/ViewController.swift
@@ -89,7 +89,7 @@ class ViewController: NSViewController {
         }
 
         let delegate = NSApplication.shared.delegate as! AppDelegate
-        delegate.togglePopover(nil)
+        delegate.handleMainEvent(nil)
     }
     
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
This PR unifies the shortcuts needed to use Pass for macOS (new feature).

* **What is the current behavior?**
Currently, you have to use two different shortcuts, one for the host app and one for the Safari extension.
A discussion about this can be found in issue #39.

* **What is the new behavior**
Both shortcuts were unified.
Now, only one shortcut is required to achieve the same behavior as before.
More details can be found in the Readme.

* **Does this PR introduce a breaking change?**
This update break compatibility with macOS Version older than 10.14.4 (Mojave), as some required APIs were not available in older versions. The readme reflects this and suggests how to cope with that.