### PR TITLE
Update homebrew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can install Pass for macOS using homebrew.
 Just run the following command:
 
 ```
-brew cask install adur1990/tap/passformacos
+brew install --cask adur1990/tap/passformaco
 ```
 
 ### Option 3: Build it yourself


### PR DESCRIPTION
`cask` is not a command anymore

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows the guidelines
- [] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs update


* **What is the current behavior?** (You can also link to an open issue here)
```
❯ brew cask install adur1990/tap/passformacos
Error: Unknown command: cask
```


* **What is the new behavior (if this is a feature change)?**
```
brew install --cask adur1990/tap/passformacos
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 36 formulae.

==> Tapping adur1990/tap
Cloning into '/usr/local/Homebrew/Library/Taps/adur1990/homebrew-tap'...
...
```


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
